### PR TITLE
Change `_p`  to `_pl`

### DIFF
--- a/src/lv_i18n.h
+++ b/src/lv_i18n.h
@@ -75,7 +75,7 @@ void __lv_i18n_reset(void);
 
 
 #define _(text) lv_i18n_get_text(text)
-#define _p(text, num) lv_i18n_get_text_plural(text, num)
+#define _pl(text, num) lv_i18n_get_text_plural(text, num)
 
 
 #ifdef __cplusplus


### PR DESCRIPTION
I don't know if it's interesting for you, but each time I compile I need to change this define because of the [framework arduinoexpressif32](https://github.com/espressif/arduino-esp32) 
```
In file included from .pio/libdeps/m5stack-core2/M5Core2/src/M5Core2.h:73,
                 from lib/Pokegotchi/Utils.h:6,
                 from lib/Pokegotchi/Menu.h:6,
                 from lib/Pokegotchi/ActionsMenu.h:6,
                 from lib/Pokegotchi/Game.h:7,
                 from lib/Pokegotchi/Game.cpp:3:
/home/got/.platformio/packages/framework-arduinoespressif32/libraries/FS/src/FS.h:50:47: error: macro "_p" requires 2 arguments, but only 1 given
     File(FileImplPtr p = FileImplPtr()) : _p(p) {
```