### PR TITLE
Add option --dump-sourceref to generate a file containing sourceKeys

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,9 @@ Example:
     one: One user is logged in
     other: '%d users are logged in'
 ```
+
+If translators want to know where a message comes from, then use `lv_i18n extract --dump-sourceref sr.json ...` to generate the file `sr.json` containing file names and line number of each message.
+
 ## Run compile to convert the yml files to a C and H file
 
 Once you have the translations in the `yml` files you only need to run the `compile` to generate a C and H files from the `yml` files. No other library will be required to get the translation with `_()` and `_p`.

--- a/lib/cmd_extract.js
+++ b/lib/cmd_extract.js
@@ -57,6 +57,14 @@ module.exports.subparserArgsList = [
       action:       'store_true',
       default: false
     }
+  },
+  {
+    args:     [ '--dump-sourceref' ],
+    options: {
+      dest:         'dump_sourceref',
+      help:         'dump the location of the extracted message keys to the given file',
+      metavar:  '<filename>'
+    }
   }
 ];
 
@@ -144,4 +152,8 @@ ${phraseObj.fileName}
   });
 
   translationKeys.saveFiles();
+
+  if (args.dump_sourceref) {
+    sourceKeys.dumpSourceRef(args.dump_sourceref);
+  }
 };

--- a/lib/source_keys.js
+++ b/lib/source_keys.js
@@ -4,7 +4,6 @@
 
 
 const glob      = require('glob').sync;
-const _         = require('lodash');
 const debug     = require('debug')('sourcee_keys');
 const AppError  = require('./app_error');
 const parse     = require('./parser');
@@ -66,8 +65,8 @@ ${this.uniques[key].fileName}, line ${this.uniques[key].line}
   dumpSourceRef(filename) {
     let result = [];
 
-    _.forEach(this.uniques, k1 => {
-      _.forEach(this.keys, k2 => {
+    Object.values(this.uniques).forEach(k1 => {
+      Object.values(this.keys).forEach(k2 => {
         if (k1.key === k2.key) {
           result.push(k2);
         }

--- a/lib/source_keys.js
+++ b/lib/source_keys.js
@@ -4,11 +4,12 @@
 
 
 const glob      = require('glob').sync;
+const _         = require('lodash');
 const debug     = require('debug')('sourcee_keys');
 const AppError  = require('./app_error');
 const parse     = require('./parser');
 
-const { readFileSync } = require('fs');
+const { readFileSync, writeFileSync } = require('fs');
 
 
 module.exports = class SourceKeys {
@@ -60,5 +61,19 @@ ${this.uniques[key].fileName}, line ${this.uniques[key].line}
     paths.forEach(p => {
       glob(p, { nodir: true }).forEach(name => this.loadFile(name));
     });
+  }
+
+  dumpSourceRef(filename) {
+    let result = [];
+
+    _.forEach(this.uniques, k1 => {
+      _.forEach(this.keys, k2 => {
+        if (k1.key === k2.key) {
+          result.push(k2);
+        }
+      });
+    });
+
+    writeFileSync(filename, JSON.stringify(result, null, 2));
   }
 };

--- a/test/js/test_cli_extract.js
+++ b/test/js/test_cli_extract.js
@@ -54,6 +54,10 @@ describe('CLI extract', function () {
     run([ 'extract', '-s', join(__dirname, 'fixtures/empty_src.c'), '-t', 'any-value' ]);
   });
 
+  it('Should exit without error with sourceref', function () {
+    run([ 'extract', '-s', join(fixtures, 'src_*.c'), '--dump-sourceref', join(fixtures, 'sourceref'),
+      '-t', join(fixtures, 'empty_en-GB.yml') ]);
+  });
 
   it('Should fill empty locales', function () {
     run([ 'extract', '-s', join(fixtures, 'src_*.c'), '-t', join(fixtures, 'empty_*.yml') ]);


### PR DESCRIPTION
This helps translators to find the context of a message to better understand the meaning of a message.
It generates (at the end of "extract") a file containing (mainly) sourceKeys in a meaningfull sorting order like:

````
[
  {
    "key": "Device init",
    "line": 384,
    "plural": false,
    "fileName": "../fc/fc.c"
  },
  {
    "key": "Device ready",
    "line": 388,
    "plural": false,
    "fileName": "../fc/fc.c"
  },
  ...
````