### PR TITLE
Support for squareline

### DIFF
--- a/lib/compiler_template.js
+++ b/lib/compiler_template.js
@@ -12,7 +12,8 @@ function to_c(locale) {
 // escape C string to write all in one line.
 function esc(str) {
   // TODO: simple & dirty, should be improved.
-  return JSON.stringify(str).slice(1, -1);
+  //return JSON.stringify(str).slice(1, -1);
+  return str;
 }
 
 const pf_enum = {


### PR DESCRIPTION
Fixed an issue where strings with escape characters generated by squareline could not be used