### PR TITLE
Feat: lv_i18n_phrase_t uses the const type

### DIFF
--- a/lib/compiler_template.js
+++ b/lib/compiler_template.js
@@ -48,7 +48,7 @@ static inline uint32_t op_e(uint32_t val) { UNUSED(val); return 0; }
 function lang_plural_template(l, form, data) {
   const loc = to_c(l);
   return `
-static lv_i18n_phrase_t ${loc}_plurals_${form}[] = {
+static const lv_i18n_phrase_t ${loc}_plurals_${form}[] = {
 ${Object.entries(data[l].plural[form]).map(([ k, val ]) => `    {"${esc(k)}", "${esc(val)}"},`).join('\n')}
     {NULL, NULL} // End mark
 };
@@ -58,7 +58,7 @@ ${Object.entries(data[l].plural[form]).map(([ k, val ]) => `    {"${esc(k)}", "$
 function lang_singular_template(l, data) {
   const loc = to_c(l);
   return `
-static lv_i18n_phrase_t ${loc}_singulars[] = {
+static const lv_i18n_phrase_t ${loc}_singulars[] = {
 ${Object.entries(data[l].singular).map(([ k, val ]) => `    {"${esc(k)}", "${esc(val)}"},`).join('\n')}
     {NULL, NULL} // End mark
 };

--- a/src/lv_i18n.h
+++ b/src/lv_i18n.h
@@ -25,8 +25,8 @@ typedef struct {
 
 typedef struct {
     const char * locale_name;
-    lv_i18n_phrase_t * singulars;
-    lv_i18n_phrase_t * plurals[_LV_I18N_PLURAL_TYPE_NUM];
+    const lv_i18n_phrase_t * singulars;
+    const lv_i18n_phrase_t * plurals[_LV_I18N_PLURAL_TYPE_NUM];
     uint8_t (*locale_plural_fn)(int32_t num);
 } lv_i18n_lang_t;
 

--- a/src/lv_i18n.template.c
+++ b/src/lv_i18n.template.c
@@ -181,7 +181,7 @@ int lv_i18n_set_locale(const char * l_name)
 }
 
 
-static const char * __lv_i18n_get_text_core(lv_i18n_phrase_t * trans, const char * msg_id)
+static const char * __lv_i18n_get_text_core(const lv_i18n_phrase_t * trans, const char * msg_id)
 {
     uint16_t i;
     for(i = 0; trans[i].msg_id != NULL; i++) {


### PR DESCRIPTION
Mark the `lv_i18n_phrase_t` array with const type to reduce RAM usage.