### PR TITLE
Add lv_i18n_get_msg_id API for reverse lookup from translated text to msg_id

### DIFF
--- a/lib/compiler_template.js
+++ b/lib/compiler_template.js
@@ -114,10 +114,12 @@ ${pforms.map(pf => `    .plurals[${pf_enum[pf]}] = ${loc}_plurals_${pf},`).join(
 }
 
 function generate_idx(keys) {
-  let result = keys.length > 0 ? '' : '    NULL,';
+  let result = '';
   Object.values(keys).forEach(k => {
     result += '    \"' + esc(k) + '\",\n';
   });
+  // Always add NULL terminator for reverse lookup
+  result += '    NULL\n';
 
   return result;
 }
@@ -149,13 +151,25 @@ ${locales.map(l => `    &${to_c(l)}_lang,`).join('\n')}
     NULL // End mark
 };
 
+// Note: singular_idx and plural_idx are not static so they can be accessed from template functions
+// This is needed for reverse lookup (get msg_id from translated text)
 #ifndef LV_I18N_OPTIMIZE
 
-static const char * singular_idx[] = {
+const char * singular_idx[] = {
 ${generate_idx(data.singularKeys)}
 };
 
-static const char * plural_idx[] = {
+const char * plural_idx[] = {
+${generate_idx(data.pluralKeys)}
+};
+
+#else
+
+const char * singular_idx[] = {
+${generate_idx(data.singularKeys)}
+};
+
+const char * plural_idx[] = {
 ${generate_idx(data.pluralKeys)}
 };
 

--- a/src/lv_i18n.template.c
+++ b/src/lv_i18n.template.c
@@ -218,10 +218,11 @@ const char * lv_i18n_get_plural_by_idx(const char * msg_id, int msg_index, int32
 #else
 // Fallback for ancient compilers, search phrase IDs in runtime (slow)
 
-static int __lv_i18n_get_id(const char * phrase, const char * * list, int len)
+static int __lv_i18n_get_id(const char * phrase, const char * * list)
 {
     uint16_t i;
-    for(i = 0; i < len; i++) {
+    // Array is NULL-terminated (added by generate_idx for reverse lookup)
+    for(i = 0; list[i] != NULL; i++) {
         if(strcmp(list[i], phrase) == 0) return i;
     }
     return LV_I18N_ID_NOT_FOUND;
@@ -229,15 +230,107 @@ static int __lv_i18n_get_id(const char * phrase, const char * * list, int len)
 
 int lv_i18n_get_singular_id(const char * phrase)
 {
-    return __lv_i18n_get_id(phrase, singular_idx, sizeof(singular_idx) / sizeof(singular_idx[0]));
+    return __lv_i18n_get_id(phrase, singular_idx);
 }
 
 int lv_i18n_get_plural_id(const char * phrase)
 {
-    return __lv_i18n_get_id(phrase, plural_idx, sizeof(plural_idx) / sizeof(plural_idx[0]));
+    return __lv_i18n_get_id(phrase, plural_idx);
 }
 
 #endif
+
+/**
+ * Helper function to search for translated text in singulars array and return the index
+ */
+static int __lv_i18n_find_singular_index(const char * translated_text)
+{
+    if(current_lang == NULL || translated_text == NULL) return LV_I18N_ID_NOT_FOUND;
+
+    const lv_i18n_lang_t * lang = current_lang;
+    
+    // Access singular_idx array defined in the generated code
+    extern const char * singular_idx[];
+    
+    // Calculate array size - this works because the array is defined in this compilation unit
+    uint16_t singular_count = 0;
+    while(singular_idx[singular_count] != NULL) {
+        singular_count++;
+        // Safety check to prevent infinite loop
+        if(singular_count > 10000) break;
+    }
+
+    // Search in current locale
+    if(lang->singulars != NULL) {
+        for(uint16_t i = 0; i < singular_count; i++) {
+            if(lang->singulars[i] != NULL && strcmp(lang->singulars[i], translated_text) == 0) {
+                return i;
+            }
+        }
+    }
+
+    // Try to fallback to default locale
+    if(lang != current_lang_pack[0]) {
+        lang = current_lang_pack[0];
+        if(lang->singulars != NULL) {
+            for(uint16_t i = 0; i < singular_count; i++) {
+                if(lang->singulars[i] != NULL && strcmp(lang->singulars[i], translated_text) == 0) {
+                    return i;
+                }
+            }
+        }
+    }
+
+    return LV_I18N_ID_NOT_FOUND;
+}
+
+/**
+ * Helper function to search for translated text in plurals array and return the index
+ */
+static int __lv_i18n_find_plural_index(const char * translated_text)
+{
+    if(current_lang == NULL || translated_text == NULL) return LV_I18N_ID_NOT_FOUND;
+
+    const lv_i18n_lang_t * lang = current_lang;
+    
+    // Access plural_idx array defined in the generated code
+    extern const char * plural_idx[];
+    
+    // Calculate array size - this works because the array is defined in this compilation unit
+    uint16_t plural_count = 0;
+    while(plural_idx[plural_count] != NULL) {
+        plural_count++;
+        // Safety check to prevent infinite loop
+        if(plural_count > 10000) break;
+    }
+
+    // Search in current locale
+    for(int ptype = 0; ptype < _LV_I18N_PLURAL_TYPE_NUM; ptype++) {
+        if(lang->plurals[ptype] != NULL) {
+            for(uint16_t i = 0; i < plural_count; i++) {
+                if(lang->plurals[ptype][i] != NULL && strcmp(lang->plurals[ptype][i], translated_text) == 0) {
+                    return i;
+                }
+            }
+        }
+    }
+
+    // Try to fallback to default locale
+    if(lang != current_lang_pack[0]) {
+        lang = current_lang_pack[0];
+        for(int ptype = 0; ptype < _LV_I18N_PLURAL_TYPE_NUM; ptype++) {
+            if(lang->plurals[ptype] != NULL) {
+                for(uint16_t i = 0; i < plural_count; i++) {
+                    if(lang->plurals[ptype][i] != NULL && strcmp(lang->plurals[ptype][i], translated_text) == 0) {
+                        return i;
+                    }
+                }
+            }
+        }
+    }
+
+    return LV_I18N_ID_NOT_FOUND;
+}
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -304,4 +397,32 @@ const char * lv_i18n_get_current_locale(void)
 {
     if(!current_lang) return NULL;
     return current_lang->locale_name;
+}
+
+/**
+ * Get the message ID from translated text
+ * @param translated_text the translated text to look up
+ * @return the message ID (msg_id) corresponding to the translated text, or NULL if not found
+ */
+const char * lv_i18n_get_msg_id(const char * translated_text)
+{
+    if(translated_text == NULL) return NULL;
+
+    extern const char * singular_idx[];
+    extern const char * plural_idx[];
+
+    // First, try to find in singulars
+    int idx = __lv_i18n_find_singular_index(translated_text);
+    if(idx != LV_I18N_ID_NOT_FOUND) {
+        return singular_idx[idx];
+    }
+
+    // Then, try to find in plurals
+    idx = __lv_i18n_find_plural_index(translated_text);
+    if(idx != LV_I18N_ID_NOT_FOUND) {
+        return plural_idx[idx];
+    }
+
+    // Not found
+    return translated_text;
 }

--- a/src/lv_i18n.template.h
+++ b/src/lv_i18n.template.h
@@ -97,6 +97,13 @@ int lv_i18n_set_locale(const char * l_name);
  */
 const char * lv_i18n_get_current_locale(void);
 
+/**
+ * Get the message ID from translated text
+ * @param translated_text the translated text to look up
+ * @return the message ID (msg_id) corresponding to the translated text, or NULL if not found
+ */
+const char * lv_i18n_get_msg_id(const char * translated_text);
+
 
 void __lv_i18n_reset(void);
 

--- a/test/c/test.c
+++ b/test/c/test.c
@@ -237,6 +237,91 @@ void test_empty_content_check(void)
     TEST_ASSERT_EQUAL_STRING(_("s_empty"), "s_empty");
 }
 
+////////////////////////////////////////////////////////////////////////////////
+
+void test_get_msg_id_should_work_for_singular(void)
+{
+    lv_i18n_init(lv_i18n_language_pack);
+
+    // Test English
+    lv_i18n_set_locale("en-GB");
+    const char * msg_id = lv_i18n_get_msg_id("s translated");
+    TEST_ASSERT_NOT_NULL(msg_id);
+    TEST_ASSERT_EQUAL_STRING(msg_id, "s_translated");
+
+    // Test Russian
+    lv_i18n_set_locale("ru-RU");
+    msg_id = lv_i18n_get_msg_id("s переведено");
+    TEST_ASSERT_NOT_NULL(msg_id);
+    TEST_ASSERT_EQUAL_STRING(msg_id, "s_translated");
+
+    // Test fallback to default locale
+    msg_id = lv_i18n_get_msg_id("english only");
+    TEST_ASSERT_NOT_NULL(msg_id);
+    TEST_ASSERT_EQUAL_STRING(msg_id, "s_en_only");
+}
+
+void test_get_msg_id_should_work_for_plural(void)
+{
+    lv_i18n_init(lv_i18n_language_pack);
+
+    // Test English plural forms - use _p() macro to get format strings
+    lv_i18n_set_locale("en-GB");
+    const char * msg_id = lv_i18n_get_msg_id(_p("p_i_have_dogs", 1));
+    TEST_ASSERT_NOT_NULL(msg_id);
+    TEST_ASSERT_EQUAL_STRING(msg_id, "p_i_have_dogs");
+
+    msg_id = lv_i18n_get_msg_id(_p("p_i_have_dogs", 2));
+    TEST_ASSERT_NOT_NULL(msg_id);
+    TEST_ASSERT_EQUAL_STRING(msg_id, "p_i_have_dogs");
+
+    msg_id = lv_i18n_get_msg_id(_p("p_i_have_dogs", 5));
+    TEST_ASSERT_NOT_NULL(msg_id);
+    TEST_ASSERT_EQUAL_STRING(msg_id, "p_i_have_dogs");
+
+    // Test Russian plural forms - use _p() macro to get format strings
+    lv_i18n_set_locale("ru-RU");
+    msg_id = lv_i18n_get_msg_id(_p("p_i_have_dogs", 1));
+    TEST_ASSERT_NOT_NULL(msg_id);
+    TEST_ASSERT_EQUAL_STRING(msg_id, "p_i_have_dogs");
+
+    msg_id = lv_i18n_get_msg_id(_p("p_i_have_dogs", 2));
+    TEST_ASSERT_NOT_NULL(msg_id);
+    TEST_ASSERT_EQUAL_STRING(msg_id, "p_i_have_dogs");
+
+    msg_id = lv_i18n_get_msg_id(_p("p_i_have_dogs", 5));
+    TEST_ASSERT_NOT_NULL(msg_id);
+    TEST_ASSERT_EQUAL_STRING(msg_id, "p_i_have_dogs");
+}
+
+void test_get_msg_id_should_return_original_text_for_not_found(void)
+{
+    lv_i18n_init(lv_i18n_language_pack);
+
+    lv_i18n_set_locale("en-GB");
+    const char * msg_id = lv_i18n_get_msg_id("not existing text");
+    TEST_ASSERT_EQUAL_STRING(msg_id, "not existing text");
+
+    lv_i18n_set_locale("ru-RU");
+    msg_id = lv_i18n_get_msg_id("несуществующий текст");
+    TEST_ASSERT_EQUAL_STRING(msg_id, "несуществующий текст");
+}
+
+void test_get_msg_id_should_return_NULL_for_NULL_input(void)
+{
+    lv_i18n_init(lv_i18n_language_pack);
+
+    const char * msg_id = lv_i18n_get_msg_id(NULL);
+    TEST_ASSERT_NULL(msg_id);
+}
+
+void test_get_msg_id_should_return_original_text_before_init(void)
+{
+    __lv_i18n_reset();
+
+    const char * msg_id = lv_i18n_get_msg_id("s translated");
+    TEST_ASSERT_EQUAL_STRING(msg_id, "s translated");
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -270,6 +355,13 @@ int main(void)
     RUN_TEST(test_empty_base_tables_fallback);
     RUN_TEST(test_empty_plurals_fallback);
     RUN_TEST(test_empty_content_check);
+
+    // lv_i18n_get_msg_id
+    RUN_TEST(test_get_msg_id_should_work_for_singular);
+    RUN_TEST(test_get_msg_id_should_work_for_plural);
+    RUN_TEST(test_get_msg_id_should_return_original_text_for_not_found);
+    RUN_TEST(test_get_msg_id_should_return_NULL_for_NULL_input);
+    RUN_TEST(test_get_msg_id_should_return_original_text_before_init);
 
     return UNITY_END();
 }


### PR DESCRIPTION
#83 

- Add lv_i18n_get_msg_id() function to get msg_id from translated text
- Modify compiler template to always generate singular_idx and plural_idx arrays for reverse lookup
- Add NULL terminator to index arrays for safe iteration
- Support both singular and plural translations lookup
- Useful for components like lv_dropdown where get_selected_text returns translated text but msg_id is needed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add lv_i18n_get_msg_id() to map translated text back to its msg_id, so components that return localized strings (like lv_dropdown) can recover stable IDs. Compiler output now includes NULL-terminated singular/plural indexes to enable safe reverse lookup.

- **New Features**
  - Added lv_i18n_get_msg_id(const char*): handles singular and plural, uses current locale with default fallback, returns original text if not found, and NULL for NULL input.
  - Added unit tests for singular, plural, fallback, NULL input, and pre-init behavior.

- **Refactors**
  - Compiler template now always emits singular_idx/plural_idx arrays, NULL-terminated and non-static for reverse lookup.
  - Runtime lookup iterates to NULL terminators and removes fixed-length scans.

<sup>Written for commit 2eace9e405069fb5e6fa69bebb121194c387ecbf. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

