### PR TITLE
chore: standardize eol and add build folders to gitignore 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+*.js text eol=lf
+*.jsx text eol=lf
+*.ts text eol=lf
+*.tsx text eol=lf
+*.json text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,7 @@ node_modules
 coverage
 .nyc_output
 *.log
+*~
+*.bak
+*.tmp
 *.swp


### PR DESCRIPTION
.gitignore a few more editor temp files and force line endings for js files(and friends) to line-feed only, in accordance with [ESLint recommendations](https://eslint.org/docs/latest/rules/linebreak-style#using-this-rule-with-version-control-systems).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force LF line endings for .js/.jsx/.ts/.tsx/.json via .gitattributes (disables autocrlf) to fix Windows linebreak issues and ESLint errors. Expand .gitignore to ignore common editor temp files (*.swp, *.tmp, *.bak, *~).

<sup>Written for commit 3caace790e6665c5e819fd74858315d44594ab87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

