### PR TITLE
ci: Bump node test versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        node-version: [16, 18, 20, 22]
+        node-version: [20, 22, 24, 25]
         # Use different OS to have different C compilers:
         os-version: [ubuntu-latest, ubuntu-22.04, ubuntu-24.04]
         # macos-14-large, macos-14, macos-13-large, macos-13


### PR DESCRIPTION
Set the active (+ maintenance) node versions as test matrix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update CI test matrix to Node.js 20, 22, 24, and 25, dropping 16 and 18. Aligns with current active and maintenance releases to keep tests relevant.

<sup>Written for commit c369218421830ad88787d96cd98e453ffec5ef97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

